### PR TITLE
feat: Background Repairs for rclone FUSE mount setup

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -46,10 +46,13 @@ jobs:
           MINOR=5
           PATCH=$(( ${{ github.run_number }} - 115 ))
 
+          # Sanitize branch name for use as a Docker tag (replace / with -)
+          SAFE_REF=$(echo "${{ github.ref_name }}" | tr '/' '-')
+
           if [[ "${{ github.ref_name }}" == "main" ]]; then
             echo "NZBDAV_VERSION=${MAJOR}.${MINOR}.${PATCH}" >> $GITHUB_OUTPUT
           else
-            echo "NZBDAV_VERSION=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+            echo "NZBDAV_VERSION=${SAFE_REF}" >> $GITHUB_OUTPUT
           fi
 
           GHCR_REPO="ghcr.io/${{ github.repository }}"
@@ -69,7 +72,7 @@ jobs:
               echo "EOF"
             } >> $GITHUB_OUTPUT
           else
-            echo "TAGS=${GHCR_REPO}:${{ github.ref_name }}" >> $GITHUB_OUTPUT
+            echo "TAGS=${GHCR_REPO}:${SAFE_REF}" >> $GITHUB_OUTPUT
           fi
 
       - name: Build and push Docker image (amd64 + arm64)

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -84,3 +84,4 @@ jobs:
           tags: ${{ steps.set_vars.outputs.TAGS }}
           build-args: |
             NZBDAV_VERSION=${{ steps.set_vars.outputs.NZBDAV_VERSION }}
+            CACHE_BUST=${{ github.sha }}

--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,4 @@ local_data/
 *.nzb
 config/
 temp_config/
-backend/local_data/
+backend/local_data/.worktrees/

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,12 +15,18 @@ RUN npm prune --omit=dev
 FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:9.0 AS backend-build
 
 WORKDIR /backend
+ARG CACHE_BUST
 COPY ./backend ./
 
-# Accept build-time architecture as ARG (e.g., x64 or arm64)
+# Map Docker TARGETARCH (amd64/arm64) to .NET RID arch suffix (x64/arm64)
 ARG TARGETARCH
-RUN dotnet restore
-RUN dotnet publish -c Release -r linux-musl-${TARGETARCH} -o ./publish
+RUN case "$TARGETARCH" in \
+      amd64) DOTNET_ARCH=x64 ;; \
+      arm64) DOTNET_ARCH=arm64 ;; \
+      *) echo "Unsupported TARGETARCH: $TARGETARCH" && exit 1 ;; \
+    esac && \
+    dotnet restore && \
+    dotnet publish -c Release -r linux-musl-$DOTNET_ARCH -o ./publish
 
 # -------- Stage 3: Combined runtime image --------
 FROM mcr.microsoft.com/dotnet/aspnet:9.0-alpine

--- a/backend/Api/Controllers/RegisterLocalLink/RegisterByLinkPathRequest.cs
+++ b/backend/Api/Controllers/RegisterLocalLink/RegisterByLinkPathRequest.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace NzbWebDAV.Api.Controllers.RegisterLocalLink;
+
+public class RegisterByLinkPathRequest
+{
+    [JsonPropertyName("linkPath")]
+    public string LinkPath { get; set; } = string.Empty;
+}

--- a/backend/Api/Controllers/RegisterLocalLink/RegisterLocalLinkController.cs
+++ b/backend/Api/Controllers/RegisterLocalLink/RegisterLocalLinkController.cs
@@ -1,0 +1,67 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Extensions;
+using NzbWebDAV.Utils;
+using Serilog;
+
+namespace NzbWebDAV.Api.Controllers.RegisterLocalLink;
+
+[ApiController]
+[Route("api/locallinks")]
+public class RegisterLocalLinkController(
+    DavDatabaseClient dbClient,
+    ConfigManager configManager
+) : ControllerBase
+{
+    [HttpPost]
+    public async Task<IActionResult> RegisterLocalLink([FromBody] RegisterLocalLinkRequest request)
+    {
+        // Validate external API key
+        var apiKey = HttpContext.GetRequestApiKey();
+        if (apiKey == null || apiKey != configManager.GetApiKey())
+            return Unauthorized(new { error = "API Key Required" });
+
+        // Validate input
+        if (string.IsNullOrWhiteSpace(request.NzoId) ||
+            string.IsNullOrWhiteSpace(request.FileName) ||
+            string.IsNullOrWhiteSpace(request.LinkPath))
+            return BadRequest(new { error = "nzoId, fileName and linkPath are required" });
+
+        if (!Guid.TryParse(request.NzoId, out var nzoId))
+            return BadRequest(new { error = "nzoId must be a valid GUID" });
+
+        // Resolve: HistoryItem → DownloadDirId → DavItem by filename
+        var historyItem = await dbClient.Ctx.HistoryItems
+            .AsNoTracking()
+            .FirstOrDefaultAsync(x => x.Id == nzoId)
+            .ConfigureAwait(false);
+
+        if (historyItem == null)
+            return NotFound(new { error = $"History item not found: {request.NzoId}" });
+
+        if (historyItem.DownloadDirId == null)
+            return NotFound(new { error = "History item has no download directory" });
+
+        var davItem = await dbClient.Ctx.Items
+            .AsNoTracking()
+            .FirstOrDefaultAsync(x =>
+                x.ParentId == historyItem.DownloadDirId &&
+                x.Name == request.FileName)
+            .ConfigureAwait(false);
+
+        if (davItem == null)
+        {
+            Log.Warning("[LocalLinks] DavItem not found for nzoId={NzoId} fileName={FileName}",
+                request.NzoId, request.FileName);
+            return NotFound(new { error = $"File '{request.FileName}' not found under download directory" });
+        }
+
+        OrganizedLinksUtil.UpdateCacheEntry(davItem.Id, request.LinkPath);
+        Log.Information("[LocalLinks] Registered: {FileName} → {LinkPath} (DavItemId={DavItemId})",
+            request.FileName, request.LinkPath, davItem.Id);
+
+        return Ok(new { davItemId = davItem.Id, message = "LocalLink registered successfully" });
+    }
+}

--- a/backend/Api/Controllers/RegisterLocalLink/RegisterLocalLinkController.cs
+++ b/backend/Api/Controllers/RegisterLocalLink/RegisterLocalLinkController.cs
@@ -15,6 +15,52 @@ public class RegisterLocalLinkController(
     ConfigManager configManager
 ) : ControllerBase
 {
+    [HttpPost("register-by-link-path")]
+    public async Task<IActionResult> RegisterByLinkPath([FromBody] RegisterByLinkPathRequest request)
+    {
+        try
+        {
+            // Validate external API key
+            var apiKey = HttpContext.GetRequestApiKey();
+            if (apiKey == null || apiKey != configManager.GetApiKey())
+                return Unauthorized(new { error = "API Key Required" });
+
+            // Validate input
+            if (string.IsNullOrWhiteSpace(request.LinkPath))
+                return BadRequest(new { error = "linkPath is required" });
+
+            // Convert arr-side mount path to nzbdav2 internal DavItem path
+            var mountDir = configManager.GetRcloneMountDir();
+            if (!request.LinkPath.StartsWith(mountDir))
+                return BadRequest(new { error = $"linkPath must start with rclone mount dir '{mountDir}'" });
+
+            var davItemPath = request.LinkPath[mountDir.Length..];
+
+            // Look up DavItem by path
+            var davItem = await dbClient.Ctx.Items
+                .AsNoTracking()
+                .FirstOrDefaultAsync(x => x.Path == davItemPath, HttpContext.RequestAborted)
+                .ConfigureAwait(false);
+
+            if (davItem == null)
+            {
+                Log.Warning("[LocalLinks] DavItem not found for linkPath={LinkPath} (davItemPath={DavItemPath})",
+                    request.LinkPath, davItemPath);
+                return NotFound(new { error = $"No DavItem found for path '{davItemPath}'" });
+            }
+
+            OrganizedLinksUtil.UpdateCacheEntry(davItem.Id, request.LinkPath);
+            Log.Information("[LocalLinks] Registered by path: {DavItemPath} → {LinkPath} (DavItemId={DavItemId})",
+                davItemPath, request.LinkPath, davItem.Id);
+
+            return Ok(new { davItemId = davItem.Id, message = "LocalLink registered successfully" });
+        }
+        catch (Exception e)
+        {
+            return StatusCode(500, new { error = e.Message });
+        }
+    }
+
     [HttpPost]
     public async Task<IActionResult> RegisterLocalLink([FromBody] RegisterLocalLinkRequest request)
     {

--- a/backend/Api/Controllers/RegisterLocalLink/RegisterLocalLinkController.cs
+++ b/backend/Api/Controllers/RegisterLocalLink/RegisterLocalLinkController.cs
@@ -18,50 +18,57 @@ public class RegisterLocalLinkController(
     [HttpPost]
     public async Task<IActionResult> RegisterLocalLink([FromBody] RegisterLocalLinkRequest request)
     {
-        // Validate external API key
-        var apiKey = HttpContext.GetRequestApiKey();
-        if (apiKey == null || apiKey != configManager.GetApiKey())
-            return Unauthorized(new { error = "API Key Required" });
-
-        // Validate input
-        if (string.IsNullOrWhiteSpace(request.NzoId) ||
-            string.IsNullOrWhiteSpace(request.FileName) ||
-            string.IsNullOrWhiteSpace(request.LinkPath))
-            return BadRequest(new { error = "nzoId, fileName and linkPath are required" });
-
-        if (!Guid.TryParse(request.NzoId, out var nzoId))
-            return BadRequest(new { error = "nzoId must be a valid GUID" });
-
-        // Resolve: HistoryItem → DownloadDirId → DavItem by filename
-        var historyItem = await dbClient.Ctx.HistoryItems
-            .AsNoTracking()
-            .FirstOrDefaultAsync(x => x.Id == nzoId)
-            .ConfigureAwait(false);
-
-        if (historyItem == null)
-            return NotFound(new { error = $"History item not found: {request.NzoId}" });
-
-        if (historyItem.DownloadDirId == null)
-            return NotFound(new { error = "History item has no download directory" });
-
-        var davItem = await dbClient.Ctx.Items
-            .AsNoTracking()
-            .FirstOrDefaultAsync(x =>
-                x.ParentId == historyItem.DownloadDirId &&
-                x.Name == request.FileName)
-            .ConfigureAwait(false);
-
-        if (davItem == null)
+        try
         {
-            Log.Warning("[LocalLinks] DavItem not found for nzoId={NzoId} fileName={FileName}",
-                request.NzoId, request.FileName);
-            return NotFound(new { error = $"File '{request.FileName}' not found under download directory" });
+            // Validate external API key
+            var apiKey = HttpContext.GetRequestApiKey();
+            if (apiKey == null || apiKey != configManager.GetApiKey())
+                return Unauthorized(new { error = "API Key Required" });
+
+            // Validate input
+            if (string.IsNullOrWhiteSpace(request.NzoId) ||
+                string.IsNullOrWhiteSpace(request.FileName) ||
+                string.IsNullOrWhiteSpace(request.LinkPath))
+                return BadRequest(new { error = "nzoId, fileName and linkPath are required" });
+
+            if (!Guid.TryParse(request.NzoId, out var nzoId))
+                return BadRequest(new { error = "nzoId must be a valid GUID" });
+
+            // Resolve: HistoryItem → DownloadDirId → DavItem by filename
+            var historyItem = await dbClient.Ctx.HistoryItems
+                .AsNoTracking()
+                .FirstOrDefaultAsync(x => x.Id == nzoId, HttpContext.RequestAborted)
+                .ConfigureAwait(false);
+
+            if (historyItem == null)
+                return NotFound(new { error = $"History item not found: {request.NzoId}" });
+
+            if (historyItem.DownloadDirId == null)
+                return NotFound(new { error = "History item has no download directory" });
+
+            var davItem = await dbClient.Ctx.Items
+                .AsNoTracking()
+                .FirstOrDefaultAsync(x =>
+                    x.ParentId == historyItem.DownloadDirId &&
+                    x.Name == request.FileName, HttpContext.RequestAborted)
+                .ConfigureAwait(false);
+
+            if (davItem == null)
+            {
+                Log.Warning("[LocalLinks] DavItem not found for nzoId={NzoId} fileName={FileName}",
+                    request.NzoId, request.FileName);
+                return NotFound(new { error = $"File '{request.FileName}' not found under download directory" });
+            }
+
+            OrganizedLinksUtil.UpdateCacheEntry(davItem.Id, request.LinkPath);
+            Log.Information("[LocalLinks] Registered: {FileName} → {LinkPath} (DavItemId={DavItemId})",
+                request.FileName, request.LinkPath, davItem.Id);
+
+            return Ok(new { davItemId = davItem.Id, message = "LocalLink registered successfully" });
         }
-
-        OrganizedLinksUtil.UpdateCacheEntry(davItem.Id, request.LinkPath);
-        Log.Information("[LocalLinks] Registered: {FileName} → {LinkPath} (DavItemId={DavItemId})",
-            request.FileName, request.LinkPath, davItem.Id);
-
-        return Ok(new { davItemId = davItem.Id, message = "LocalLink registered successfully" });
+        catch (Exception e)
+        {
+            return StatusCode(500, new { error = e.Message });
+        }
     }
 }

--- a/backend/Api/Controllers/RegisterLocalLink/RegisterLocalLinkRequest.cs
+++ b/backend/Api/Controllers/RegisterLocalLink/RegisterLocalLinkRequest.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+
+namespace NzbWebDAV.Api.Controllers.RegisterLocalLink;
+
+public class RegisterLocalLinkRequest
+{
+    [JsonPropertyName("nzoId")]
+    public string NzoId { get; set; } = string.Empty;
+
+    [JsonPropertyName("fileName")]
+    public string FileName { get; set; } = string.Empty;
+
+    [JsonPropertyName("linkPath")]
+    public string LinkPath { get; set; } = string.Empty;
+}

--- a/backend/Api/SabControllers/GetHistory/GetHistoryResponse.cs
+++ b/backend/Api/SabControllers/GetHistory/GetHistoryResponse.cs
@@ -1,6 +1,7 @@
 using System.Text.Json.Serialization;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database.Models;
+using Serilog;
 
 namespace NzbWebDAV.Api.SabControllers.GetHistory;
 
@@ -110,7 +111,8 @@ public class GetHistoryResponse : SabBaseResponse
                 });
             }
 
-            throw new Exception("Unknown import strategy");
+            Log.Warning("[GetDownloadPath] Unknown import strategy '{Strategy}'. Valid: 'strm', 'symlinks'. Arr client will receive no storage path.", importStrategy);
+            return null; // Unknown strategy: omits 'storage' from history response; valid values are "strm" and "symlinks"
         }
     }
 }

--- a/backend/Clients/RadarrSonarr/RadarrClient.cs
+++ b/backend/Clients/RadarrSonarr/RadarrClient.cs
@@ -26,8 +26,73 @@ public class RadarrClient(string host, string apiKey) : ArrClient(host, apiKey)
         CommandAsync(new { name = "MoviesSearch", movieIds = new List<int> { id } });
 
 
-    public override Task<bool> RemoveAndSearch(string symlinkOrStrmPath, int? episodeId = null, string sortKey = "date", string sortAtrection = "descending") =>
-        Task.FromResult(false);
+    public override async Task<bool> RemoveAndSearch(string symlinkOrStrmPath, int? episodeId = null, string sortKey = "date", string sortDirection = "descending")
+    {
+        Log.Information($"[ArrClient] Attempting to remove and search for '{symlinkOrStrmPath}' in Radarr '{Host}'");
+
+        var mediaIds = await GetMediaIds(symlinkOrStrmPath);
+        if (mediaIds == null)
+        {
+            Log.Warning($"[ArrClient] Could not find media IDs for '{symlinkOrStrmPath}' in Radarr. Aborting RemoveAndSearch.");
+            return false;
+        }
+
+        // 1. Get scene name before deletion for history lookup
+        var movie = await GetMovieAsync(mediaIds.Value.movieId);
+        var sceneName = movie.MovieFile?.SceneName;
+
+        // 2. Delete the movie file
+        Log.Information($"[ArrClient] Deleting movie file ID {mediaIds.Value.movieFileId} from Radarr...");
+        if (await DeleteMovieFile(mediaIds.Value.movieFileId) != System.Net.HttpStatusCode.OK)
+            throw new Exception($"Failed to delete movie file '{symlinkOrStrmPath}' from Radarr instance '{Host}'.");
+
+        Log.Information($"[ArrClient] Successfully deleted movie file ID {mediaIds.Value.movieFileId}.");
+
+        // 3. Try to find the grab event in history and mark it failed (blacklist + auto-search)
+        if (!string.IsNullOrEmpty(sceneName))
+        {
+            try
+            {
+                var history = await GetHistoryAsync(movieId: mediaIds.Value.movieId, sortKey: sortKey, sortDirection: sortDirection);
+                var grabEvent = history.Records
+                    .FirstOrDefault(x =>
+                        x.SourceTitle != null &&
+                        x.SourceTitle.Equals(sceneName, StringComparison.OrdinalIgnoreCase) &&
+                        x.Data != null &&
+                        x.Data.TryGetValue("protocol", out var protocol) &&
+                        protocol == "1" // 1 = usenet
+                    );
+
+                if (grabEvent != null)
+                {
+                    Log.Information($"[ArrClient] Found grab event ID {grabEvent.Id}. Attempting to mark as failed...");
+                    if (await MarkHistoryFailedAsync(grabEvent.Id))
+                    {
+                        Log.Information($"[ArrClient] Successfully marked history item {grabEvent.Id} as failed for '{sceneName}' in Radarr '{Host}'.");
+                        return true;
+                    }
+                    Log.Warning($"[ArrClient] Failed to mark history item {grabEvent.Id} as failed. Proceeding to fallback search.");
+                }
+                else
+                {
+                    Log.Warning($"[ArrClient] Could not find grab event in history for '{sceneName}' in Radarr '{Host}'. Proceeding to fallback search.");
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Warning($"[ArrClient] Error while attempting to mark history failed for '{sceneName}' in Radarr '{Host}': {ex.Message}. Proceeding to fallback search.");
+            }
+        }
+        else
+        {
+            Log.Warning($"[ArrClient] SceneName was null or empty for movie file. Proceeding to fallback search.");
+        }
+
+        // 4. Fallback: trigger a new movie search
+        Log.Information($"[ArrClient] Triggering fallback search for movie ID {mediaIds.Value.movieId}...");
+        await SearchMovieAsync(mediaIds.Value.movieId);
+        return true;
+    }
 
     public async Task<(int movieFileId, int movieId)?> GetMediaIds(string symlinkOrStrmPath)
     {

--- a/backend/Clients/RadarrSonarr/SonarrClient.cs
+++ b/backend/Clients/RadarrSonarr/SonarrClient.cs
@@ -148,21 +148,29 @@ public class SonarrClient(string host, string apiKey) : ArrClient(host, apiKey)
             if (episodeFile.Path == symlinkOrStrmPath) return episodeFileId;
         }
 
-        // otherwise, find the series-id
-        var seriesId = await GetSeriesId(symlinkOrStrmPath);
-        if (seriesId == null) return null;
+        // When all series share the same root path (e.g. /mnt/nzbdav/content/tv),
+        // GetSeriesId returns the first match which may not be correct. Instead,
+        // find ALL series whose path is a prefix of the target, ordered by most
+        // specific first, and search each one's episode files until we find a match.
+        var allSeries = await GetAllSeries();
+        var matchingSeries = allSeries
+            .Where(s => s.Path != null && symlinkOrStrmPath.StartsWith(s.Path))
+            .OrderByDescending(s => s.Path!.Length)
+            .ToList();
 
-        // then use it to find all episode-files and repopulate the cache
-        int? result = null;
-        foreach (var episodeFile in await GetAllEpisodeFiles(seriesId.Value))
+        foreach (var series in matchingSeries)
         {
-            SymlinkOrStrmToEpisodeFileIdCache[episodeFile.Path!] = episodeFile.Id;
-            if (episodeFile.Path == symlinkOrStrmPath)
-                result = episodeFile.Id;
+            SeriesPathToSeriesIdCache[series.Path!] = series.Id;
+            foreach (var episodeFile in await GetAllEpisodeFiles(series.Id))
+            {
+                if (episodeFile.Path != null)
+                    SymlinkOrStrmToEpisodeFileIdCache[episodeFile.Path] = episodeFile.Id;
+                if (episodeFile.Path == symlinkOrStrmPath)
+                    return episodeFile.Id;
+            }
         }
 
-        // return the found episode-file-id
-        return result;
+        return null;
     }
 
     public async Task<int?> GetSeriesId(string symlinkOrStrmPath)

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -56,11 +56,8 @@ class Program
 
         // Log build version to verify correct build is running
         Log.Warning("═══════════════════════════════════════════════════════════════");
-        Log.Warning("  NzbDav Backend Starting - BUILD v2026-01-15-STATS-NORMALIZE");
-        Log.Warning("  FEATURE: Fix real-time stats grouping duplicates");
-        Log.Warning("  - StatsController now uses normalized AffinityKey from context");
-        Log.Warning("  - Prevents duplicate entries (e.g., 'Movie.mkv' vs 'Movie')");
-        Log.Warning("  - Falls back to normalized path extraction if AffinityKey missing");
+        Log.Warning("  NzbDav Backend Starting - BUILD v2026-02-22-BACKGROUND-REPAIRS");
+        Log.Warning("  FEATURE: LocalLinks API for rclone-mount repair support");
         Log.Warning("═══════════════════════════════════════════════════════════════");
 
         // Run Arr History Tester if requested

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -763,11 +763,14 @@ public class HealthCheckService
             }
             else
             {
-                deleteMessage = $"Deleting file '{symlinkOrStrmPath}' and associated NzbDav item '{davItem.Path}'.";
+                // Regular file on rclone FUSE mount — do not delete directly.
+                deleteMessage = $"File '{symlinkOrStrmPath}' is a regular mount path and was NOT deleted. Removing associated NzbDav item '{davItem.Path}'.";
             }
 
             Log.Warning($"[HealthCheck] Could not find corresponding Radarr/Sonarr media-item for file: {davItem.Name}. {deleteMessage}");
-            await Task.Run(() => File.Delete(symlinkOrStrmPath)).ConfigureAwait(false);
+            // Only delete symlinks and strm files; regular rclone mount paths must not be deleted directly.
+            if (linkInfoToDelete is SymlinkAndStrmUtil.SymlinkInfo or SymlinkAndStrmUtil.StrmInfo)
+                await Task.Run(() => File.Delete(symlinkOrStrmPath)).ConfigureAwait(false);
             dbClient.Ctx.Items.Remove(davItem);
             OrganizedLinksUtil.RemoveCacheEntry(davItem.Id);
             dbClient.Ctx.HealthCheckResults.Add(SendStatus(new HealthCheckResult()

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -654,8 +654,13 @@ public class HealthCheckService
 
             // if the unhealthy item is linked within the organized media-library
             // then we must find the corresponding arr instance and trigger a new search.
-            var linkType = symlinkOrStrmPath.ToLower().EndsWith("strm") ? "strm-file"
-                : (new FileInfo(symlinkOrStrmPath).LinkTarget != null ? "symlink" : "file");
+            var resolvedLinkInfo = SymlinkAndStrmUtil.GetSymlinkOrStrmInfo(new FileInfo(symlinkOrStrmPath));
+            var linkType = resolvedLinkInfo switch
+            {
+                SymlinkAndStrmUtil.StrmInfo    => "strm-file",
+                SymlinkAndStrmUtil.SymlinkInfo => "symlink",
+                _                              => "file"
+            };
 
             foreach (var arrClient in _configManager.GetArrConfig().GetArrClients())
             {
@@ -667,7 +672,7 @@ public class HealthCheckService
 
                 // Safety Check: Ensure the file points to our mount
                 var mountDir = _configManager.GetRcloneMountDir();
-                var linkInfo = SymlinkAndStrmUtil.GetSymlinkOrStrmInfo(new FileInfo(symlinkOrStrmPath));
+                var linkInfo = resolvedLinkInfo;
                 if (linkInfo is SymlinkAndStrmUtil.SymlinkInfo symInfo && !symInfo.TargetPath.StartsWith(mountDir))
                 {
                     Log.Warning($"[HealthCheck] Safety check failed: Symlink {symlinkOrStrmPath} points to {symInfo.TargetPath}, which is outside mount dir {mountDir}. Skipping Arr delete.");
@@ -675,7 +680,7 @@ public class HealthCheckService
                 }
 
                 // Capture link info before deletion for logging
-                var arrLinkInfo = SymlinkAndStrmUtil.GetSymlinkOrStrmInfo(new FileInfo(symlinkOrStrmPath));
+                var arrLinkInfo = resolvedLinkInfo;
                 string linkTargetMsg = "";
                 if (arrLinkInfo is SymlinkAndStrmUtil.SymlinkInfo sInfo)
                     linkTargetMsg = $" (Symlink target: '{sInfo.TargetPath}')";

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -654,7 +654,8 @@ public class HealthCheckService
 
             // if the unhealthy item is linked within the organized media-library
             // then we must find the corresponding arr instance and trigger a new search.
-            var linkType = symlinkOrStrmPath.ToLower().EndsWith("strm") ? "strm-file" : "symlink";
+            var linkType = symlinkOrStrmPath.ToLower().EndsWith("strm") ? "strm-file"
+                : (new FileInfo(symlinkOrStrmPath).LinkTarget != null ? "symlink" : "file");
 
             foreach (var arrClient in _configManager.GetArrConfig().GetArrClients())
             {

--- a/backend/Utils/OrganizedLinksUtil.cs
+++ b/backend/Utils/OrganizedLinksUtil.cs
@@ -361,12 +361,24 @@ public static class OrganizedLinksUtil
     private static bool Verify(string linkFromCache, DavItem targetDavItem, ConfigManager configManager)
     {
         var fileInfo = new FileInfo(linkFromCache);
-        if (!fileInfo.Exists) return false; // Basic existence check
+
+        // Paths outside the library dir (e.g. arr-path-fixer rclone mount paths) are not
+        // mounted inside this container. Skip the existence check and trust the LocalLink;
+        // Repair() will handle stale paths gracefully if the file is already gone.
+        var libraryDir = configManager.GetLibraryDir();
+        var libDirPrefix = string.IsNullOrEmpty(libraryDir)
+            ? null
+            : libraryDir.TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+        if (libDirPrefix == null || !linkFromCache.StartsWith(libDirPrefix))
+            return true;
+
+        // Library path: must exist on disk
+        if (!fileInfo.Exists) return false;
 
         var symlinkOrStrmInfo = SymlinkAndStrmUtil.GetSymlinkOrStrmInfo(fileInfo);
         if (symlinkOrStrmInfo == null)
         {
-            // Regular file (e.g. rclone FUSE mount path) — trust LocalLinks, existence is sufficient
+            // Regular file inside the library dir — existence confirmed above
             return true;
         }
 

--- a/backend/Utils/OrganizedLinksUtil.cs
+++ b/backend/Utils/OrganizedLinksUtil.cs
@@ -345,12 +345,18 @@ public static class OrganizedLinksUtil
 
     private static bool Verify(string linkFromCache, DavItem targetDavItem, ConfigManager configManager)
     {
-        var mountDir = configManager.GetRcloneMountDir();
         var fileInfo = new FileInfo(linkFromCache);
-        if (!fileInfo.Exists) return false; // Basic check
+        if (!fileInfo.Exists) return false; // Basic existence check
 
         var symlinkOrStrmInfo = SymlinkAndStrmUtil.GetSymlinkOrStrmInfo(fileInfo);
-        if (symlinkOrStrmInfo == null) return false;
+        if (symlinkOrStrmInfo == null)
+        {
+            // Regular file (e.g. rclone FUSE mount path) — trust LocalLinks, existence is sufficient
+            return true;
+        }
+
+        // Symlink or .strm: verify it actually points to this DavItem
+        var mountDir = configManager.GetRcloneMountDir();
         var davItemLink = GetDavItemLink(symlinkOrStrmInfo, mountDir);
         return davItemLink?.DavItemId == targetDavItem.Id;
     }

--- a/backend/Utils/OrganizedLinksUtil.cs
+++ b/backend/Utils/OrganizedLinksUtil.cs
@@ -278,15 +278,23 @@ public static class OrganizedLinksUtil
                 }
             }
 
+            // Paths registered by arr-path-fixer are outside the library dir and are not
+            // visible from inside this container, so only remove LocalLinks whose paths
+            // are inside the library dir. External paths are cleaned up via FK CASCADE
+            // when their DavItem is deleted.
+            var libraryDir = configManager.GetLibraryDir();
+            var libDirPrefix = string.IsNullOrEmpty(libraryDir)
+                ? null
+                : libraryDir.TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+
             foreach (var dbLink in dbLinks)
             {
                 if (!onDiskMap.ContainsKey(dbLink.LinkPath))
                 {
-                    // Don't remove regular-file LocalLinks (e.g. rclone FUSE mount paths).
-                    // They are not symlinks/strm so they never appear in onDiskMap, but they
-                    // are still valid as long as the file exists on the mount.
-                    var fi = new FileInfo(dbLink.LinkPath);
-                    if (fi.Exists && SymlinkAndStrmUtil.GetSymlinkOrStrmInfo(fi) == null)
+                    // Only remove links that live inside the library directory.
+                    // Links outside (e.g. rclone mount paths from arr-path-fixer)
+                    // are invisible to this container and must not be purged here.
+                    if (libDirPrefix == null || !dbLink.LinkPath.StartsWith(libDirPrefix))
                         continue;
 
                     toRemove.Add(dbLink);

--- a/backend/Utils/OrganizedLinksUtil.cs
+++ b/backend/Utils/OrganizedLinksUtil.cs
@@ -282,6 +282,13 @@ public static class OrganizedLinksUtil
             {
                 if (!onDiskMap.ContainsKey(dbLink.LinkPath))
                 {
+                    // Don't remove regular-file LocalLinks (e.g. rclone FUSE mount paths).
+                    // They are not symlinks/strm so they never appear in onDiskMap, but they
+                    // are still valid as long as the file exists on the mount.
+                    var fi = new FileInfo(dbLink.LinkPath);
+                    if (fi.Exists && SymlinkAndStrmUtil.GetSymlinkOrStrmInfo(fi) == null)
+                        continue;
+
                     toRemove.Add(dbLink);
                 }
             }


### PR DESCRIPTION
## Summary

- Add `POST /api/locallinks` endpoint so arr-path-fixer can register rclone mount paths in nzbdav2's LocalLinks table after each import
- Fix `OrganizedLinksUtil.Verify()` to trust LocalLinks for paths outside the library dir (arr-path-fixer paths not visible from inside the container)
- Fix `SyncLinksAsync` to only remove LocalLinks inside the library dir; external paths are cleaned up via FK CASCADE when their DavItem is deleted
- Implement `RadarrClient.RemoveAndSearch` (was stub returning false — Radarr repairs were silently no-ops)
- Fix `Repair()` fallback to skip `File.Delete` on regular rclone mount paths
- Fix `GetDownloadPath` to log and return `null` for unknown import strategy instead of throwing
- Improve `linkType` label in repair log output (uses `GetSymlinkOrStrmInfo` to distinguish "symlink" / "strm-file" / "file")

## How it works

1. arr-path-fixer imports a file → calls `POST /api/locallinks` with `{ nzoId, fileName, linkPath }`
2. nzbdav2 resolves `nzoId` → `HistoryItem` → `DavItem` by filename, writes LocalLink
3. HealthCheckService detects unhealthy segments → `Repair()` finds the LocalLink → tells Sonarr/Radarr to delete and re-search

## Container architecture note

arr-path-fixer's import paths (e.g. `/volume1/media/movies/...`) are not mounted inside nzbdav2's container. The library dir (`/content`) is the only path nzbdav2 can see. Fixes in this PR account for this:
- `Verify()`: trusts any LocalLink path outside the library dir (existence check only applies inside the library dir)
- `SyncLinksAsync`: only removes stale LocalLinks inside the library dir; external arr-path-fixer paths survive sync cycles and are cleaned up via FK CASCADE

## Test image

CI builds a test image tagged `ghcr.io/dgherman/nzbdav2:feature-background-repairs`

## Integration test results

- ✅ `POST /api/locallinks` returns `{ davItemId, message }` for valid nzoId
- ✅ LocalLink written to `db.sqlite` `LocalLinks` table
- ✅ LocalLinks outside library dir survive `SyncLinksAsync` cycles (not purged)

## Test plan

- [ ] Deploy test image alongside updated arr-path-fixer
- [ ] Enable `repair.enable = true` in nzbdav2 web UI (Repairs tab)
- [ ] Monitor logs for `LocalLink registered:` messages from arr-path-fixer after poll cycle
- [ ] Verify `LocalLinks` appear in `db.sqlite` after arr-path-fixer import
- [ ] Wait for HealthCheckService to detect an unhealthy item — confirm Sonarr/Radarr re-search fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)
