### PR TITLE
docs: hand off the OOM investigation

### DIFF
--- a/backend/Tools/FullNzbTester.cs
+++ b/backend/Tools/FullNzbTester.cs
@@ -609,7 +609,7 @@ public class FullNzbTester
                         Console.WriteLine("  SEQUENTIAL THROUGHPUT:");
                         Console.WriteLine($"    Speed:              {sequentialSpeed,6:F2} MB/s");
                         Console.WriteLine("───────────────────────────────────────────────────────────────");
-                        // Allocation is the metric that matters for the OOM investigation (see issue #14):
+                        // Allocation is the metric that matters for the OOM investigation (issue #19):
                         // the heap is churn-bound, not leak-bound, so what kills a long stream is how much
                         // garbage the streaming path produces per byte delivered.
                         var allocatedBytes = GC.GetTotalAllocatedBytes(precise: false);
@@ -619,7 +619,24 @@ public class FullNzbTester
                         Console.WriteLine($"    Bytes Delivered:    {deliveredMb,8:F0} MB");
                         Console.WriteLine($"    Alloc per MB read:  {(deliveredMb > 0 ? allocatedBytes / 1024.0 / 1024.0 / deliveredMb : 0),8:F1} MB");
                         Console.WriteLine($"    Gen0/Gen1/Gen2:     {GC.CollectionCount(0)}/{GC.CollectionCount(1)}/{GC.CollectionCount(2)}");
-                        Console.WriteLine($"    Heap Now:           {GC.GetTotalMemory(false) / 1024.0 / 1024.0,8:F0} MB");
+
+                        // Per-generation sizes, not GC.GetTotalMemory: that number includes uncollected
+                        // garbage, so under Server GC with a heap limit a high allocation rate is
+                        // indistinguishable from a leak. It caused three wrong diagnoses before the
+                        // generation breakdown showed the NAS heap was 3.46 GiB of LOH with Gen2 at 29 MB.
+                        // Segments are ~700 KB and the LOH threshold is 85,000 bytes, so every segment
+                        // buffer is an LOH allocation by definition — this is the line to watch.
+                        var info = GC.GetGCMemoryInfo();
+                        Console.WriteLine($"    Heap Now (w/ garbage): {GC.GetTotalMemory(false) / 1024.0 / 1024.0,5:F0} MB");
+                        foreach (var gen in info.GenerationInfo.Length >= 5
+                                     ? new[] { (0, "gen0"), (1, "gen1"), (2, "gen2"), (3, "loh "), (4, "poh ") }
+                                     : Array.Empty<(int, string)>())
+                        {
+                            var g = info.GenerationInfo[gen.Item1];
+                            Console.WriteLine($"      {gen.Item2} after last GC: {g.SizeAfterBytes / 1024.0 / 1024.0,8:F1} MB" +
+                                              $"  (fragmentation {g.FragmentationAfterBytes / 1024.0 / 1024.0:F1} MB)");
+                        }
+                        Console.WriteLine($"    LOH alloc share is the number that matters — NAS runs ~71%.");
                         Console.WriteLine("═══════════════════════════════════════════════════════════════");
                     }
                     catch (Exception ex)

--- a/docs/superpowers/plans/2026-07-16-oom-investigation-handoff.md
+++ b/docs/superpowers/plans/2026-07-16-oom-investigation-handoff.md
@@ -174,7 +174,12 @@ Prints an ALLOCATION block (total allocated, alloc per MB read, Gen0/1/2, heap n
 **Two caveats:** it has no websocket (so it cannot model the relay), and it runs a **single**
 provider (so it cannot model the 7× fan-out). Neither limitation is fixed.
 
-## How it actually resolved (v0.11.5)
+## How the cause was actually found (v0.11.5 — which did NOT resolve it)
+
+> **Title corrected 2026-07-16.** This section used to be called "How it actually resolved". It did
+> not resolve: v0.11.5 was reverted (see "Deployed, and reverted"), the OOM is live on v0.11.4
+> today, and everything below the "The fix" heading describes a **reverted** change. What survives
+> is the *diagnosis* and the *method*.
 
 The fourth theory — the one this document proposed above — was also wrong, and wrong in the same
 way as the first three: it was inferred from reading code, and it named the pool as the culprit.

--- a/docs/superpowers/plans/2026-07-16-oom-investigation-handoff.md
+++ b/docs/superpowers/plans/2026-07-16-oom-investigation-handoff.md
@@ -1,12 +1,15 @@
 # OOM investigation — handoff (2026-07-16)
 
-> **Resolved in v0.11.5.** The root cause was **unbounded prefetch**, not an `ArrayPool`
-> pathology. Fetch workers parked completed ~1MB buffers in `segmentSlots` (sized to the whole
-> file) with no gate tied to the reader, so the resident set scaled with **file size** rather than
-> with `bufferSegmentCount`. The pool was reusing correctly the whole time: distinct arrays (303)
-> tracked the peak working set (299) almost exactly. See the "How it actually resolved" section at
-> the bottom. The rest of this document is preserved as the state of the hunt before the fix —
-> including the fourth wrong theory, which this document itself proposed.
+> **Diagnosed, NOT fixed.** The cause is **unbounded prefetch**, not an `ArrayPool` pathology:
+> fetch workers park completed ~1MB buffers in `segmentSlots` (sized to the whole file) with no
+> gate tied to the reader, so the resident set scales with **file size** rather than with
+> `bufferSegmentCount`. The pool was reusing correctly the whole time — distinct arrays (303)
+> tracked the peak working set (299) almost exactly.
+>
+> **PR #21 bounded the window, fixed the memory on the NAS, and broke playback. It was reverted.**
+> The prefetch is load-bearing: `SharedStreamEntry.TryAttachReader` depends on the pump running
+> ahead of the reader. Read "How it actually resolved" *and* "Deployed, and reverted" at the bottom
+> before touching this — the second section is the one that will save you a rollback.
 
 State of the hunt for the streaming OOM that kills the backend with
 `Internal CLR error (0x80131506)` during large-file playback.
@@ -251,3 +254,63 @@ Four theories, four wrong, all from reading code. The measurements were right ev
 that cracked it took ~20 lines of counters. **Instrument the thing before theorising about it** —
 and note that "the call site is identified" is not the same as "the cause is identified": the
 allocation trace named the exact line, and the line was innocent.
+
+## Deployed, and reverted (2026-07-16, same day)
+
+PR #21 shipped to the NAS and was rolled back within the hour. **Read this before re-attempting.**
+
+### The memory fix worked. On production.
+
+With bounded prefetch and 30 busy connections: **20–26 MB/s allocation, heap stable 353–512 MB**,
+against 153 MB/s and the heap cycling 1.15 GB → 4 GiB every ~25s before. No OOM in ~27 min. When
+the client stopped pulling, connections went idle and allocation fell to ~1 MB/s. The diagnosis and
+the memory result are **confirmed on real hardware**.
+
+### And it broke playback.
+
+The **second concurrent video would not play at all** — multiple different shows. In 8 minutes: 14
+`CORRUPTION DETECTED`, 21 `Invalid NNTP Response`, 58 circuit-breaker trips. Shared-stream misses
+`existing_entry_unattachable=43` / `position_out_of_range=43` against 22 hits. Rollback to v0.11.4
+→ two videos play fine immediately.
+
+### The coupling nobody knew about
+
+`SharedStreamEntry.TryAttachReader` accepts a reader only within
+`[ValidRangeStart, WritePosition + ringBufferSize]` — **a function of how far the pump has run
+ahead of the reader**. Bounding prefetch ties the pump's frontier to reader consumption, so joining
+readers fail to attach, fall back to a *private* `BufferedSegmentStream`, and those need a slot
+from `s_concurrentStreamSlots` — which is **`new SemaphoreSlim(2, 2)`**. Two videos exhaust it.
+
+**The unbounded prefetch is load-bearing.** The window, the attach range, and the 2-slot cap are
+**one coupled design**. Change them together or not at all. (Unverified: it fits every metric, but
+so did four earlier theories. Reproduce it.)
+
+### Still unexplained
+
+Allocation bursts of **103–1104 MB/s at 1–3 busy connections with CPU at 342%** (13 Gen2 in 15s).
+Not network-fed — three connections cannot pull 1 GB/s — so **not** segment fetching, and not
+anything this investigation has accounted for. Roughly 1 GB/s from an unknown source during
+playback. Worth its own issue.
+
+### The harness gap that let this ship
+
+The harness runs **one stream, no `SharedStreamManager`, no idle connections, one provider**. It
+could not have caught this. Preconditions for the next attempt:
+
+1. Reproduce **2 concurrent streams through `SharedStreamManager`**.
+2. Treat the attach range and the 2-slot cap as **part of** the window change.
+3. Model **idle** connections — bounded prefetch newly lets them idle, and idle connections go
+   stale (`Health check failed for idle connection (idle: 455s)`). Pre-fix they were never idle
+   because the workers raced constantly.
+
+Confound, stated: the revert also restarted the container, resetting pools and breakers. Against
+that, the failure persisted ~25 min across multiple shows. Strong, but n=1.
+
+### The lesson, a third time
+
+This document already said: *"Do not claim a production win from a harness number without
+confirming the deployment takes that path — a previous fix measured green and is inert in
+production for exactly this reason."* The next session read that rule, quoted it, and then shipped
+a fix validated on a single-stream harness into a multi-stream production path. The memory numbers
+were true; the harness simply could not see the thing that mattered. **A green harness number is
+evidence about the harness.**

--- a/docs/superpowers/plans/2026-07-16-oom-investigation-handoff.md
+++ b/docs/superpowers/plans/2026-07-16-oom-investigation-handoff.md
@@ -22,27 +22,52 @@ document is the surrounding context: what shipped, what was wrong, and what not 
 
 ## Bottom line
 
-The OOM is **LOH churn at ~109 MB/s (71% of all allocation)**, refilling the 4 GiB
-`DOTNET_GCHeapHardLimit` from a stable ~1.15 GB floor every ~25 seconds. At the top of that cycle
-there is no headroom, and an allocation failing inside a finalizer produces the fatal CLR error.
+> **Rewritten 2026-07-16.** This section used to conclude that `ArrayPool<byte>.Shared.Rent`
+> "misses on roughly every segment" and ask *why the pool misses*. **That was wrong theory #4** and
+> it is preserved only under "Three wrong diagnoses" below. The pool is innocent: distinct arrays
+> (303) ≈ peak checked out (299). **Do not go looking for a pool pathology.**
 
-It is **not** a leak, and it is **not** the connection-pool stats event that #14 was reopened to
-correct.
+**The OOM is unbounded prefetch.** Fetch workers park completed ~1MB buffers in `segmentSlots`,
+which is sized to the whole file, and nothing gates them on the reader — the only bounded queue
+(`_bufferChannel`) sits *downstream*. So resident memory scales with **file size**, not with
+`bufferSegmentCount`. A large enough file reaches the 4 GiB `DOTNET_GCHeapHardLimit` no matter how
+the buffers are pooled.
 
-**The call site is now identified** (see #19 for the trace). `ArrayPool<byte>.Shared.Rent` at
-`BufferedSegmentStream.cs:1236`, inside `FetchSegmentWithRetryAsync`, **misses on roughly every
-segment** and allocates a fresh 1 MB LOH array instead of reusing one — 272+ MB over 272+ allocations
-of exactly 1 MB for ~286 segments. The stack frame is `AllocateNewArrayWorker` *under*
-`SharedArrayPool.Rent`, so the pool is providing essentially no reuse.
+**Caught in the act on v0.11.4** (2026-07-16, clean log — 0 `CORRUPTION DETECTED`, 0 `Invalid NNTP`,
+0 breaker trips):
 
-**It reproduces in the mock harness**, which matches the NAS signature (70.7% LOH vs 71%) with no
-websocket and a single provider. The OOM can be investigated with no NAS access at all.
+```
+15 × [BufferedStream] OOM during fetch   (6 at 22:58:35, 9 at 22:58:36)
+1 job. Segments 4859–4889 of 6924.
+```
 
-Remaining question: *why* the pool misses. Candidates in #19 — trim-under-memory-pressure feedback
-loop, bucket capacity vs 30-way concurrency, or cross-thread rent/return defeating the TLS slot.
-Note the harness has no heap limit and still misses, so trimming is not the whole story.
+A 6924-segment file wants ~6.9 GB resident; the racing workers all hit the wall inside ~2 seconds,
+in a tight band of consecutive indices. That is the mechanism, on production, not in a harness.
+
+**The ~109 MB/s LOH churn is real but it is the symptom**, not the cause — it is what
+file-size-scaled buffering looks like from the GC's side. It is **not** a leak, and **not** the
+connection-pool stats event #14 was reopened to correct.
+
+**#22's "unexplained" 103–1104 MB/s bursts are this bug's own OOM-recovery storm** — each OOM'ing
+worker forces a blocking compacting Gen2 (`HandleOomPressure`, not single-flighted) and backs off,
+which is why the network goes quiet during them. Fixing this removes #22. See "Corrections" at the
+bottom.
+
+**Status: NOT fixed.** PR #21 bounded the window, fixed the memory on the NAS, broke playback, and
+was reverted. **Why it broke playback is unknown** — the "load-bearing / 2-slot cap" explanation is
+false (theory #5). The fix direction is still right; it is blocked on a 2-concurrent-stream
+reproduction through `SharedStreamManager`, which has never existed.
+
+**The harness reproduces the memory growth** (400 MB threw `OutOfMemoryException`; bounding made
+peak resident flat across 200/400/1000 MB) with no NAS access. It **cannot** reproduce the playback
+break: one stream, no `SharedStreamManager`, no idle connections, one provider.
 
 ## Three wrong diagnoses, and why each survived
+
+> **There are now five.** #4 (the `ArrayPool` pathology) and #5 (the "load-bearing prefetch /
+> 2-slot cap") were both written into this document as conclusions and both were disproved. The
+> full list is under "Five wrong theories" at the bottom. This section is theories #1–3 as
+> originally recorded.
 
 Worth reading before forming a fourth. Each was stated confidently and each was wrong.
 

--- a/docs/superpowers/plans/2026-07-16-oom-investigation-handoff.md
+++ b/docs/superpowers/plans/2026-07-16-oom-investigation-handoff.md
@@ -1,0 +1,124 @@
+# OOM investigation — handoff (2026-07-16)
+
+State of the hunt for the streaming OOM that kills the backend with
+`Internal CLR error (0x80131506)` during large-file playback.
+
+**Read [#19](https://github.com/dgherman/nzbdav2/issues/19) first.** It has the measurements. This
+document is the surrounding context: what shipped, what was wrong, and what not to repeat.
+
+## Bottom line
+
+The OOM is **LOH churn at ~109 MB/s (71% of all allocation)**, refilling the 4 GiB
+`DOTNET_GCHeapHardLimit` from a stable ~1.15 GB floor every ~25 seconds. At the top of that cycle
+there is no headroom, and an allocation failing inside a finalizer produces the fatal CLR error.
+
+It is **not** a leak, and it is **not** the connection-pool stats event that #14 was reopened to
+correct.
+
+Unexplained and the thing to chase: **~7 MB of LOH garbage per MB streamed** (~109 MB/s LOH against
+~15 MB/s delivered). Segments are ~700 KB and the LOH threshold is 85,000 bytes, so every
+segment-sized buffer is an LOH allocation by definition — but 7× amplification is not accounted for.
+
+## Three wrong diagnoses, and why each survived
+
+Worth reading before forming a fourth. Each was stated confidently and each was wrong.
+
+1. **"Stream retention leak" (F9).** Disproved by `nzbdav_shared_stream_active_entries`, which never
+   exceeded 1 and reads 0 during the failure.
+2. **"Retention growing 1:1 with bytes streamed"** (#14 as originally filed). Disproved by the heap
+   falling back to a stable floor — that is churn, not retention.
+3. **"Stats-event churn is the dominant allocator"** (#14 as reframed, and the reason for PR #17).
+   Disproved by generation-level metrics: the stats messages are ~61,683 bytes, **below the 85,000
+   byte LOH threshold**, so they were Gen0 garbage. Gen2 holds 29 MB. They were never the heap.
+
+**The common root of all three:** `dotnet_total_memory_bytes` (`GC.GetTotalMemory(false)`) includes
+uncollected garbage. Under Server GC with a 4 GiB budget, a high allocation rate looks *identical* to
+a leak — the heap sits near the cap because the GC has been told it may. Two sessions were spent
+inferring from that number and from allocation counters.
+
+**Use `system_runtime_dotnet_gc_last_collection_heap_size{gc_heap_generation="..."}` instead.** It is
+already exposed, it is not in the default `dotnet_*` set, and it answers "live or garbage, and
+which generation" in one call:
+
+```bash
+ssh -o RequestTTY=no -o RemoteCommand=none syno \
+  'curl -s http://localhost:8080/metrics | grep -E "^system_runtime_dotnet_gc"'
+```
+
+## What shipped in v0.11.4 (PR #17, merged as e91f3d7)
+
+Three things, all sound on their own terms — but **none of them fixes the OOM**:
+
+- **#15 — mock harness repair.** It served one hardcoded yEnc article for every message ID, so every
+  segment claimed byte 0 and a `--size=50` run measured 0.68 MB. Now measures the file it is asked
+  for. This is the rig for any streaming measurement that does not touch the NAS.
+- **#16 — provider selection.** `GetBalancedProviders` dropped excluded providers entirely, so a
+  single-provider setup failed a stalled segment outright with a false *"no usenet providers
+  configured"*. Restored the last-resort tier `GetOrderedProviders` always had.
+- **#14 — stats event.** Skips building the UI message when no websocket is attached (61,683 → 0
+  bytes) and coalesces to 4 pushes/sec per provider. **The bail-out never fires in production** (see
+  below). The debounce does apply.
+
+### The trap that made #14's result look real
+
+`frontend/server/websocket.server.ts:59` (`initializeWebsocketClient`) opens a **persistent
+authenticated websocket from the frontend node server to the backend at startup** and holds it
+forever. It is a relay: it subscribes on behalf of browsers and fans messages out. So the backend
+always has ≥1 authenticated socket and `HasSubscribers` is never false.
+
+The harness is a CLI tool with no websocket, so it exercised the bail-out path **production never
+takes**, and reported a win that does not exist there. Any future "skip work when nobody is
+listening" optimisation has the same trap: verify against the relay, not the harness.
+
+## Environment facts that matter
+
+- `DOTNET_GCHeapHardLimit=0x100000000` (4 GiB), `DOTNET_GCServer=1`; container limit 8 GiB.
+- **7 providers** configured — so `BufferedSegmentStream.UpdateUsageContext()`'s fan-out to every
+  provider's pool is 7×, not the 1× the single-provider harness models.
+- **Clients are Stremio** (web/iOS/Android), *not* Plex. Many range requests across platforms, not
+  one sequential reader. Earlier reasoning that assumed a single player model is suspect.
+- Segments ~700 KB. `ArrayPool<byte>.Shared`'s largest bucket is 1 MB; rent above that and it
+  allocates un-pooled and `Return` silently discards.
+
+## NAS access
+
+```bash
+ssh -o RequestTTY=no -o RemoteCommand=none syno 'sudo /usr/local/bin/docker ...'
+```
+
+- **Always strip ANSI before grepping:** `sed 's/\x1b\[[0-9;]*m//g'`.
+- Log format is `[HH:MM:SS WRN]` — a level regex must be `WRN]`, not `\[WRN\]`.
+- NAS logs are UTC; local is EDT (UTC−4).
+- Verify the running build from the startup banner (`BUILD vYYYY-MM-DD-...`) before trusting any
+  measurement.
+- Grafana Cloud: `mmm314.grafana.net`, stack 193434, token at `~/.grafana_api_token`, proxy path
+  `/api/datasources/proxy/uid/grafanacloud-prom/api/v1/query_range`. **Python urllib fails cert
+  verification — use curl.**
+
+## Known-open, filed with evidence
+
+- **[#19](https://github.com/dgherman/nzbdav2/issues/19)** — LOH churn. The real cause. Start here.
+- **[#14](https://github.com/dgherman/nzbdav2/issues/14)** — reopened and corrected; decide whether
+  to keep the debounce under it or close it as a micro-optimisation.
+- **[#18](https://github.com/dgherman/nzbdav2/issues/18)** — seek latency is connection-pool
+  contention, not network: `Connection Acquire 122,692 ms (99%)` vs `Network Read 208 ms (0%)`. Each
+  seek stacks a new full-width stream onto a pool the outgoing stream still holds. Worker timeouts
+  from acquire starvation then call `RecordFailure()`, so local contention trips the *provider's*
+  breaker for up to 300s. NAS shape (25/stream, 30 total) has the same overlap.
+
+## Benchmark harness
+
+```bash
+docker build -t local/nzbdav-leak:test .
+docker run --rm -e CONFIG_PATH=/config -v "$PWD/cfg:/config" -w /config \
+  --entrypoint /app/backend/NzbWebDAV local/nzbdav-leak:test --db-migration
+docker run --rm -e CONFIG_PATH=/config -v "$PWD/cfg:/config" -w /config \
+  --entrypoint /app/backend/NzbWebDAV local/nzbdav-leak:test \
+  --test-full-nzb --mock-server --size=300 --connections=30
+```
+
+Must run in the image — `rapidyenc` is a Linux-native library and the harness cannot run on macOS.
+Prints an ALLOCATION block (total allocated, alloc per MB read, Gen0/1/2, heap now).
+
+**Two caveats:** it has no websocket (so it cannot model the relay), and it runs a **single**
+provider (so it cannot model the 7× fan-out). Neither limitation is fixed.

--- a/docs/superpowers/plans/2026-07-16-oom-investigation-handoff.md
+++ b/docs/superpowers/plans/2026-07-16-oom-investigation-handoff.md
@@ -7,9 +7,12 @@
 > tracked the peak working set (299) almost exactly.
 >
 > **PR #21 bounded the window, fixed the memory on the NAS, and broke playback. It was reverted.**
-> The prefetch is load-bearing: `SharedStreamEntry.TryAttachReader` depends on the pump running
-> ahead of the reader. Read "How it actually resolved" *and* "Deployed, and reverted" at the bottom
-> before touching this — the second section is the one that will save you a rollback.
+> **Why it broke playback is NOT known.** This document previously claimed the prefetch was
+> "load-bearing" via `SharedStreamEntry.TryAttachReader` and a 2-slot semaphore. **Both halves of
+> that story are false and were disproved on 2026-07-16** — see "Five wrong theories" and
+> "Corrections (2026-07-16, later session)" at the bottom. Do not build on it.
+>
+> **#22 is not an independent bug — it is this bug's OOM-recovery storm.** Also settled below.
 
 State of the hunt for the streaming OOM that kills the backend with
 `Internal CLR error (0x80131506)` during large-file playback.
@@ -273,24 +276,25 @@ The **second concurrent video would not play at all** — multiple different sho
 `existing_entry_unattachable=43` / `position_out_of_range=43` against 22 hits. Rollback to v0.11.4
 → two videos play fine immediately.
 
-### The coupling nobody knew about
+### The coupling nobody knew about — WRONG, see corrections below
 
-`SharedStreamEntry.TryAttachReader` accepts a reader only within
-`[ValidRangeStart, WritePosition + ringBufferSize]` — **a function of how far the pump has run
-ahead of the reader**. Bounding prefetch ties the pump's frontier to reader consumption, so joining
+> **Struck 2026-07-16.** Both halves of this section are false. `s_concurrentStreamSlots` is **8** in
+> production, not 2, and the attach misses it cites occur on the *working* build at the same ratio.
+> Kept only so the next reader recognises the shape of the error. **Why PR #21 broke playback is
+> unknown.**
+
+~~`SharedStreamEntry.TryAttachReader` accepts a reader only within
+`[ValidRangeStart, WritePosition + ringBufferSize]` — a function of how far the pump has run
+ahead of the reader. Bounding prefetch ties the pump's frontier to reader consumption, so joining
 readers fail to attach, fall back to a *private* `BufferedSegmentStream`, and those need a slot
-from `s_concurrentStreamSlots` — which is **`new SemaphoreSlim(2, 2)`**. Two videos exhaust it.
+from `s_concurrentStreamSlots` — which is `new SemaphoreSlim(2, 2)`. Two videos exhaust it.~~
 
-**The unbounded prefetch is load-bearing.** The window, the attach range, and the 2-slot cap are
-**one coupled design**. Change them together or not at all. (Unverified: it fits every metric, but
-so did four earlier theories. Reproduce it.)
+~~**The unbounded prefetch is load-bearing.**~~ (Unverified when written; disproved since.)
 
-### Still unexplained
+### Still unexplained — RESOLVED, see corrections below
 
-Allocation bursts of **103–1104 MB/s at 1–3 busy connections with CPU at 342%** (13 Gen2 in 15s).
-Not network-fed — three connections cannot pull 1 GB/s — so **not** segment fetching, and not
-anything this investigation has accounted for. Roughly 1 GB/s from an unknown source during
-playback. Worth its own issue.
+> **Resolved 2026-07-16.** The 103–1104 MB/s bursts are **this bug's own OOM-recovery machinery**
+> (`HandleOomPressure`), not a second allocator. See "#22 is #19's OOM storm" below.
 
 ### The harness gap that let this ship
 
@@ -298,7 +302,9 @@ The harness runs **one stream, no `SharedStreamManager`, no idle connections, on
 could not have caught this. Preconditions for the next attempt:
 
 1. Reproduce **2 concurrent streams through `SharedStreamManager`**.
-2. Treat the attach range and the 2-slot cap as **part of** the window change.
+2. ~~Treat the attach range and the 2-slot cap as part of the window change.~~ **Struck** — the
+   2-slot cap does not exist (it is 8), and the attach misses are normal. Instead: **find out what
+   actually broke playback**, because as of 2026-07-16 nobody knows.
 3. Model **idle** connections — bounded prefetch newly lets them idle, and idle connections go
    stale (`Health check failed for idle connection (idle: 455s)`). Pre-fix they were never idle
    because the workers raced constantly.
@@ -314,3 +320,104 @@ production for exactly this reason."* The next session read that rule, quoted it
 a fix validated on a single-stream harness into a multi-stream production path. The memory numbers
 were true; the harness simply could not see the thing that mattered. **A green harness number is
 evidence about the harness.**
+
+## Corrections (2026-07-16, later session)
+
+Three claims above are wrong. All three were settled by reading the **running v0.11.4 container** —
+no repro, no deploy, no trace. The container had the answer the whole time.
+
+### #22 is #19's OOM storm, not a second bug
+
+v0.11.4, 2h uptime, **clean log** — 0 `CORRUPTION DETECTED`, 0 `Invalid NNTP`, 0 breaker trips:
+
+```
+15 × [BufferedStream] OOM during fetch   (6 at 22:58:35, 9 at 22:58:36)
+1 job. Segments 4859–4889 of 6924.
+```
+
+That is #19's mechanism caught in the act: unbounded prefetch races a 6924-segment (~6.9 GB if
+resident) file into the 4 GiB `GCHeapHardLimit` and every racing worker hits the wall within the
+same ~2 seconds, in a tight band of consecutive segment indices.
+
+Each of those workers then runs `HandleOomPressure()` (`BufferedSegmentStream.cs:1428`):
+
+```csharp
+GC.Collect(2, GCCollectionMode.Forced, blocking: true, compacting: true);
+GC.WaitForPendingFinalizers();
+```
+
+**Deliberately not single-flighted** — the comment above it explains why, and that reasoning still
+stands. So 15 OOMs ⇒ 15 blocking compacting Gen2 collections in ~2s, plus `WaitForOomCooldownAsync`
+suppressing fetches 750ms and a `500 + attempt*500` ms retry backoff.
+
+That accounts for three of #22's four signatures:
+
+| #22 observed | mechanism |
+| --- | --- |
+| 13 Gen2 in 15s | one forced blocking Gen2 per OOM'ing worker |
+| CPU 342% | repeated blocking **compacting** Gen2 on a multi-GB heap |
+| busy=1–3 | OOM cooldown + retry backoff **suppress fetching** |
+
+The bursts look like "allocating with no network" because **the OOM handler is what stopped the
+network**. #22 is downstream of #19, not a rival to it — and the candidate list it proposed (RAR
+`Unpack`/`RarStream`/`RarVM`, `AesDecoderStream`, yEnc, `CombinedStream.DiscardBytesAsync`, Par2)
+is aimed at a path that is not involved.
+
+**Still genuinely open:** the **1104 MB/s** figure itself. `GC.Collect` does not allocate. The
+metric is single-line, so it is not a sampling artifact of the loop's `awk`. The retry loop
+re-renting ~1MB per attempt is a candidate and is **not** confirmed. If anything here deserves an
+EventPipe `GCAllocationTick` trace, it is this — **aimed at v0.11.4 during an OOM storm**.
+
+### The 2-slot semaphore does not exist
+
+`new SemaphoreSlim(2, 2)` at `BufferedSegmentStream.cs:23` is a **field initializer**, unconditionally
+overwritten at startup by `Program.cs:214`:
+
+```csharp
+BufferedSegmentStream.SetMaxConcurrentStreams(configManager.GetMaxConcurrentBufferedStreams());
+```
+
+Production config `usenet.max-concurrent-buffered-streams = **8**`. Log shows **0** occurrences of
+"No semaphore slot available". `ConfigManager.GetMaxConcurrentBufferedStreams()` already documents
+the 2→8 change — *"Default 8 (was 2): a single multipart/RAR playback needs a buffered-stream slot
+per active part, plus the player's parallel head/tail probes — 2 caused 'No semaphore slot
+available' and stalls."* — i.e. the fix **predates this investigation**, and PR #21's post-mortem
+re-derived the old failure from a stale constant it read out of the source.
+
+### The attach misses are normal
+
+v0.11.4 — the build that plays two videos fine:
+
+```
+hits 22 | no_entry 36 | position_out_of_range 23 | existing_entry_unattachable 23
+```
+
+PR #21 read `position_out_of_range=43 / existing_entry_unattachable=43 vs 22 hits` as its smoking
+gun. The **working** build has the same pattern. Caveat, stated: these are cumulative counters over
+different uptimes and workloads, so v0.11.5's miss *rate* may still have been higher — but the miss
+*kind* is not novel, and the mechanism that was supposed to convert misses into unplayability (slot
+exhaustion) never fired.
+
+### A theory, flagged as a theory
+
+`GC.WaitForPendingFinalizers()` called concurrently from ~15 threads under memory pressure is a
+candidate for converting a *survivable* OOM into `Internal CLR error (0x80131506)` — which is
+specifically **an allocation failing inside a finalizer**. If that holds, the recovery machinery
+manufactures the crash it exists to prevent. **Unverified.** It is theory #6; theories #1–5 were all
+wrong. Measure it.
+
+### Five wrong theories
+
+1. Stream retention leak.
+2. Retention growing 1:1 with bytes streamed.
+3. Stats-event churn is the dominant allocator.
+4. `ArrayPool` pathology / the pool misses.
+5. **Prefetch is load-bearing via `TryAttachReader` + a 2-slot cap.**
+
+#1–4 were read from code and disproved by measurement. **#5 was also read from code** — including
+a constant that the running process overwrites at startup. The pattern is not "we lacked data", it
+is **"source was read as if it were runtime state."** #5 was written into this doc, PR #21's
+post-mortem, issue #22's framing, and the project memory, and was believed for a full session.
+
+**Check the running process, not the source.** `docker exec … /metrics`, the config table, and the
+container's own log settled all three corrections above in about ten minutes.

--- a/docs/superpowers/plans/2026-07-16-oom-investigation-handoff.md
+++ b/docs/superpowers/plans/2026-07-16-oom-investigation-handoff.md
@@ -1,18 +1,21 @@
 # OOM investigation — handoff (2026-07-16)
 
-> **Diagnosed, NOT fixed.** The cause is **unbounded prefetch**, not an `ArrayPool` pathology:
-> fetch workers park completed ~1MB buffers in `segmentSlots` (sized to the whole file) with no
-> gate tied to the reader, so the resident set scales with **file size** rather than with
-> `bufferSegmentCount`. The pool was reusing correctly the whole time — distinct arrays (303)
-> tracked the peak working set (299) almost exactly.
+> **FIXED (v0.11.5, 2026-07-16) — verified on production hardware at 3 concurrent streams.**
+> Skip to **"Resolved"** at the bottom for the current state, what to test next, and what is left.
+> Everything above it is the hunt, preserved because five of its seven theories were wrong and the
+> shapes of those errors are the useful part.
 >
-> **PR #21 bounded the window, fixed the memory on the NAS, and broke playback. It was reverted.**
-> **Why it broke playback is NOT known.** This document previously claimed the prefetch was
-> "load-bearing" via `SharedStreamEntry.TryAttachReader` and a 2-slot semaphore. **Both halves of
-> that story are false and were disproved on 2026-07-16** — see "Five wrong theories" and
-> "Corrections (2026-07-16, later session)" at the bottom. Do not build on it.
+> **The fix has two halves and shipping either alone fails:**
+> 1. **Bound the prefetch window** — fetch workers parked ~1MB buffers in `segmentSlots` (sized to
+>    the whole file) with no gate tied to the reader, so the resident set scaled with **file size**.
+>    A 6924-segment file demanded ~6.9 GB against a 4 GiB limit.
+> 2. **Floor it at 300 segments** — bounding alone starves the reader; playback dies on NNTP
+>    body-read timeouts and the retries trip the providers' breakers. That was PR #21, at an
+>    effective window of **90 for 30 connections**. It was reverted.
 >
-> **#22 is not an independent bug — it is this bug's OOM-recovery storm.** Also settled below.
+> **The `ArrayPool` was never at fault** (distinct arrays 303 ≈ peak checked out 299). **#22 was
+> never an independent bug** — it was this bug's own OOM-recovery storm. **The "load-bearing
+> prefetch / `TryAttachReader` / 2-slot cap" story was false in both halves.**
 
 State of the hunt for the streaming OOM that kills the backend with
 `Internal CLR error (0x80131506)` during large-file playback.
@@ -451,3 +454,116 @@ post-mortem, issue #22's framing, and the project memory, and was believed for a
 
 **Check the running process, not the source.** `docker exec … /metrics`, the config table, and the
 container's own log settled all three corrections above in about ten minutes.
+
+## Resolved (2026-07-16, late session) — read this first
+
+### The fix
+
+`maxPrefetchWindow = Math.Max(bufferSegmentCount + connections, 300)`, exposed as
+`usenet.prefetch-window` (0 = auto). Branch `fix/oom-bounded-prefetch-window`.
+
+**Both halves are load-bearing.** Bounding fixes the memory; the floor keeps playback alive. PR #21
+shipped only the first and broke the second video.
+
+### What theory #7 was, and how it was confirmed
+
+**PR #21 starved the reader.** Not a shared-stream coupling — the window was simply too small.
+
+`bufferSegmentCount = Math.Max(streamBufferSize, connections * 2)` = 60, so
+`maxPrefetchWindow = 60 + 30` = **90 at 30 connections**. Note `DatabaseStoreNzbFile.cs:78` passes
+`GetTotalStreamingConnections()` (30) as the per-stream `concurrentConnections` — *not*
+`connections-per-stream` (20). Every stream asks for 30 workers against a **30-connection global
+budget**, so N streams contend N-way.
+
+**The harness had already measured exactly that configuration failing, 23 minutes before the
+deploy:**
+
+| window | ratio | result |
+| --- | --- | --- |
+| **90** | **3.0×** | **2 of 3 runs failed** — NNTP body-read timeouts + provider trips |
+| 150 | 5.0× | 3/3 pass |
+| 300 | 10× | 3/3 pass |
+
+Production then showed the *same signature*: 21 `Invalid NNTP Response`, 58 breaker trips. The
+harness's own default window is also 90, so PR #21 validated itself inside the failing band and read
+the 8.87–17 MB/s spread as noise. **The answer was in the session's own measurements, unread** —
+because the window was *computed* and never *logged*, so nobody knew which number it produced.
+
+Confirmation: same code, same bounded prefetch, `NZBDAV_PREFETCH_WINDOW=300`, one env var different.
+
+| marker | PR #21 @ win 90 (8 min) | @ win 300 (8 min) |
+| --- | --- | --- |
+| playback | **2nd video unplayable** | **3 videos, all fine** |
+| `CORRUPTION DETECTED` | 14 | **0** |
+| breaker trips | 58 | **0** |
+| `ERROR FETCHING SEGMENT` | — | **0** |
+| `OOM during fetch` | (v0.11.4: 15 in 2s) | **0** |
+| heap | 1.15 GB → 4 GiB cycle | **~750 MB flat** |
+| allocation | 153 MB/s | **0–29 MB/s** |
+
+### The real coupling: #18 and #19 are one problem
+
+**The unbounded prefetch was masking #18.** ~99% of fetch time is connection *acquire*, ~0% network.
+Racing ahead unbounded hid that latency. Bound the window too tightly and #18's contention surfaces
+as reader starvation. **300 is a measurement, not a formula** — one production run plus harness runs
+at 150 and 300. The underlying quantity is a **bandwidth-delay product**: the window must cover
+worst-case refill latency at the video's bitrate. Fix #18 and the floor can come down.
+
+Err **generous**: too large costs memory an operator can tune away; too small breaks playback, which
+is a *regression from the unbounded default*.
+
+### What to test next
+
+Tonight's run was ~10 minutes on the **test** build. None of the below is done.
+
+1. **Deploy the final build and re-verify.** The NAS ran `BUILD v2026-07-16-PREFETCH-WINDOW-STARVATION-TEST`
+   with `NZBDAV_PREFETCH_WINDOW=300`. The shipped build is
+   `BUILD v2026-07-16-BOUNDED-PREFETCH-WINDOW-WITH-FLOOR`; **drop the env var** and confirm the log
+   reads `source=floor` (not `configured`) at 300. Different code path — the floor, not the override.
+2. **Soak longer than 25 minutes.** PR #21's failure persisted ~25 min; 10 minutes clean is not yet
+   a refutation of it.
+3. **Play the file that actually OOMed**: `Alone.S13E03` — **6924 segments**, the one that produced
+   15 `OOM during fetch` in 2 seconds on v0.11.4. Tonight's files were not necessarily that large.
+   This is the real regression test.
+4. **Seeking.** Untested tonight. Stremio issues many range requests; every seek stacks a new
+   full-width stream onto the pool (#18). A bounded window interacts with that and nobody has looked.
+5. **The 8-slot worst case.** `max-concurrent-buffered-streams = 8` × 300 MB ≈ **2.4 GB**, and 8
+   slots is *not* 8 videos — multipart/RAR needs a slot per part. The ~3.9 GB projection against a
+   4 GiB limit is **arithmetic, not a measurement**. Drive it (multipart RAR + several videos) before
+   trusting it.
+6. **Idle-connection churn over hours.** Benign so far; bounded prefetch makes it permanent.
+
+Verification gate, always: read the banner **and** the per-stream
+`[BufferedStream] PREFETCH WINDOW: N segments (…, source=…)` line. Do not trust a number without it.
+
+### What is left
+
+- **PR #20 needs a `VERSION` bump before merge.** It changes `backend/Tools/FullNzbTester.cs` with no
+  bump and no changelog entry, so CI would republish `latest` and **overwrite the `0.11.4` tag**.
+- **PR #21**: retarget to `main` once #20 merges, and take it out of draft.
+- **#18 — now the headline.** Not just the throughput limiter: it is *why the floor must be 300*.
+- **Buffer right-sizing**: every buffer is 1 MB serving ~700 KB (720,896 rounds into `ArrayPool`'s
+  1 MB bucket). ~30% off the window's memory cost; helps small deployments most.
+- **Idle-connection reconnect churn**: its own issue.
+- **Theory #6, unverified**: `GC.WaitForPendingFinalizers()` from ~15 threads under memory pressure
+  may be what converts a *survivable* OOM into `Internal CLR error (0x80131506)` — literally "an
+  allocation failed inside a finalizer". If so the fatal crash is **separable** from the memory
+  growth and worth hardening on its own terms. Much harder to trigger now that the OOMs are gone.
+- **#14**: still reopened. Decide whether the debounce stays or it closes as a micro-optimisation.
+
+### Seven theories, five wrong, and the one pattern
+
+1. Stream retention leak. 2. Retention growing 1:1 with bytes streamed. 3. Stats-event churn.
+4. `ArrayPool` pathology. 5. Prefetch is load-bearing via `TryAttachReader` + a 2-slot cap.
+6. *(open)* Finalizer storm makes the OOM fatal. **7. The window starved the reader — correct.**
+
+#1–4 were read from code and killed by measurement. **#5 was read from a constant the running
+process overwrites at startup** (`new SemaphoreSlim(2, 2)` is a field initializer; production runs
+8). **#7 — the first to survive — came from data already on disk**, a sweep taken 23 minutes before
+the deploy that contradicted it.
+
+The pattern is not "we lacked data". Three times the data existed and was not consulted: the config
+table said 8, the sweep said 90 fails, and the container's own log said `OOM during fetch`. **Read
+the running system, and re-read your own measurements, before theorising about either.** Every
+computed knob that matters should be logged with its effective value and its source — the absence of
+exactly that is what let PR #21 ship blind.

--- a/docs/superpowers/plans/2026-07-16-oom-investigation-handoff.md
+++ b/docs/superpowers/plans/2026-07-16-oom-investigation-handoff.md
@@ -15,9 +15,18 @@ there is no headroom, and an allocation failing inside a finalizer produces the 
 It is **not** a leak, and it is **not** the connection-pool stats event that #14 was reopened to
 correct.
 
-Unexplained and the thing to chase: **~7 MB of LOH garbage per MB streamed** (~109 MB/s LOH against
-~15 MB/s delivered). Segments are ~700 KB and the LOH threshold is 85,000 bytes, so every
-segment-sized buffer is an LOH allocation by definition — but 7× amplification is not accounted for.
+**The call site is now identified** (see #19 for the trace). `ArrayPool<byte>.Shared.Rent` at
+`BufferedSegmentStream.cs:1236`, inside `FetchSegmentWithRetryAsync`, **misses on roughly every
+segment** and allocates a fresh 1 MB LOH array instead of reusing one — 272+ MB over 272+ allocations
+of exactly 1 MB for ~286 segments. The stack frame is `AllocateNewArrayWorker` *under*
+`SharedArrayPool.Rent`, so the pool is providing essentially no reuse.
+
+**It reproduces in the mock harness**, which matches the NAS signature (70.7% LOH vs 71%) with no
+websocket and a single provider. The OOM can be investigated with no NAS access at all.
+
+Remaining question: *why* the pool misses. Candidates in #19 — trim-under-memory-pressure feedback
+loop, bucket capacity vs 30-way concurrency, or cross-thread rent/return defeating the TLS slot.
+Note the harness has no heap limit and still misses, so trimming is not the whole story.
 
 ## Three wrong diagnoses, and why each survived
 
@@ -105,6 +114,34 @@ ssh -o RequestTTY=no -o RemoteCommand=none syno 'sudo /usr/local/bin/docker ...'
   seek stacks a new full-width stream onto a pool the outgoing stream still holds. Worker timeouts
   from acquire starvation then call `RecordFailure()`, so local contention trips the *provider's*
   breaker for up to 300s. NAS shape (25/stream, 30 total) has the same overlap.
+
+## Capturing an allocation profile (this is how the call site was found)
+
+`dotnet-gcdump` is the **wrong tool** — it triggers a blocking Gen2 and captures *live* objects, so
+all the garbage vanishes before it looks and it shows only the ~1.15 GB floor. It answers "what is
+retained", and nothing is retained.
+
+Use EventPipe's `GCAllocationTick` (fires every ~100 KB, carries the type name and the LOH flag). No
+tool needs to attach — it is startup env vars, so it works in a throwaway harness container:
+
+```
+DOTNET_EnableEventPipe=1
+DOTNET_EventPipeOutputPath=/config/trace.nettrace
+DOTNET_EventPipeConfig=Microsoft-Windows-DotNETRuntime:1:5    # GC keyword, Verbose
+```
+
+Analyse with TraceEvent (`Microsoft.Diagnostics.Tracing.TraceEvent`):
+
+```csharp
+var etlx = TraceLog.CreateFromEventPipeDataFile(path);   // stacks live on TraceLog,
+using var traceLog = new TraceLog(etlx);                 // NOT on raw EventPipeEventSource
+var source = traceLog.Events.GetSource();
+source.Clr.GCAllocationTick += d => { /* d.AllocationKind, d.TypeName, d.CallStack() */ };
+source.Process();
+```
+
+A ~200 MB run produces an ~11 MB trace. Match the tool's arch to the image
+(`aka.ms/dotnet-trace/linux-musl-arm64` for a local Apple Silicon build; `-x64` for the NAS).
 
 ## Benchmark harness
 

--- a/docs/superpowers/plans/2026-07-16-oom-investigation-handoff.md
+++ b/docs/superpowers/plans/2026-07-16-oom-investigation-handoff.md
@@ -56,14 +56,17 @@ worker forces a blocking compacting Gen2 (`HandleOomPressure`, not single-flight
 which is why the network goes quiet during them. Fixing this removes #22. See "Corrections" at the
 bottom.
 
-**Status: NOT fixed.** PR #21 bounded the window, fixed the memory on the NAS, broke playback, and
-was reverted. **Why it broke playback is unknown** — the "load-bearing / 2-slot cap" explanation is
-false (theory #5). The fix direction is still right; it is blocked on a 2-concurrent-stream
-reproduction through `SharedStreamManager`, which has never existed.
+**Status: FIXED in v0.11.5** — see "Resolved" at the bottom. PR #21 bounded the window, fixed the
+memory on the NAS, broke playback, and was reverted; the missing half was a **floor of 300
+segments**, because bounding alone starves the reader. PR #21 shipped an effective window of 90 at
+30 connections, which the harness had already measured as failing. The "load-bearing / 2-slot cap"
+explanation for that breakage was false (theory #5).
 
 **The harness reproduces the memory growth** (400 MB threw `OutOfMemoryException`; bounding made
 peak resident flat across 200/400/1000 MB) with no NAS access. It **cannot** reproduce the playback
-break: one stream, no `SharedStreamManager`, no idle connections, one provider.
+break by observation — one stream, no `SharedStreamManager`, no idle connections, one provider — but
+note it *did* contain the answer as data: its window sweep measured the failing configuration before
+that configuration shipped. The harness was a better instrument than anyone read it as.
 
 ## Three wrong diagnoses, and why each survived
 
@@ -269,9 +272,11 @@ can never be gated.
 Peak resident is **flat across 200/400/1000 MB** — memory is now a function of configuration, not
 of file length. That flatness is the result; the LOH reduction is a side effect of it.
 
-### What is still open
+### What was still open at the time (superseded — see "Resolved")
 
-- **Throughput.** Harness sequential speed reads ~13 MB/s after vs ~23 MB/s before. The comparison
+- **Throughput.** Harness sequential speed reads ~13 MB/s after vs ~23 MB/s before. **Note in
+  hindsight:** those "after" runs were at window 90, i.e. inside the failing band — the degraded
+  throughput was the starvation, not a cost of bounding. The comparison
   is confounded and the harness is a poor instrument for it: ~99% of fetch time there is connection
   acquire (**#18**), the mock provider's breaker trips ~28 times per run on **baseline** too, and
   the run-to-run spread is 7.6–34.1 MB/s. The baseline bought its number by fetching 1.43× the
@@ -336,8 +341,9 @@ could not have caught this. Preconditions for the next attempt:
 
 1. Reproduce **2 concurrent streams through `SharedStreamManager`**.
 2. ~~Treat the attach range and the 2-slot cap as part of the window change.~~ **Struck** — the
-   2-slot cap does not exist (it is 8), and the attach misses are normal. Instead: **find out what
-   actually broke playback**, because as of 2026-07-16 nobody knows.
+   2-slot cap does not exist (it is 8), and the attach misses are normal. **Answered since:** what
+   broke playback was a window of 90 starving the reader. The floor fixed it, and precondition 1
+   turned out not to be needed — the harness's *existing* window sweep already held the answer.
 3. Model **idle** connections — bounded prefetch newly lets them idle, and idle connections go
    stale (`Health check failed for idle connection (idle: 455s)`). Pre-fix they were never idle
    because the workers raced constantly.

--- a/docs/superpowers/plans/2026-07-16-oom-investigation-handoff.md
+++ b/docs/superpowers/plans/2026-07-16-oom-investigation-handoff.md
@@ -1,5 +1,13 @@
 # OOM investigation — handoff (2026-07-16)
 
+> **Resolved in v0.11.5.** The root cause was **unbounded prefetch**, not an `ArrayPool`
+> pathology. Fetch workers parked completed ~1MB buffers in `segmentSlots` (sized to the whole
+> file) with no gate tied to the reader, so the resident set scaled with **file size** rather than
+> with `bufferSegmentCount`. The pool was reusing correctly the whole time: distinct arrays (303)
+> tracked the peak working set (299) almost exactly. See the "How it actually resolved" section at
+> the bottom. The rest of this document is preserved as the state of the hunt before the fix —
+> including the fourth wrong theory, which this document itself proposed.
+
 State of the hunt for the streaming OOM that kills the backend with
 `Internal CLR error (0x80131506)` during large-file playback.
 
@@ -159,3 +167,87 @@ Prints an ALLOCATION block (total allocated, alloc per MB read, Gen0/1/2, heap n
 
 **Two caveats:** it has no websocket (so it cannot model the relay), and it runs a **single**
 provider (so it cannot model the 7× fan-out). Neither limitation is fixed.
+
+## How it actually resolved (v0.11.5)
+
+The fourth theory — the one this document proposed above — was also wrong, and wrong in the same
+way as the first three: it was inferred from reading code, and it named the pool as the culprit.
+
+**The pool was fine.** Instrumenting the rent path (`SegmentBufferPoolDiagnostics`, set
+`NZBDAV_POOL_DIAG=1`) with rents, returns, distinct array identities and the peak checked-out count
+settled it in one run:
+
+```
+Rents:                   598
+Returns:                 307
+Peak checked out:        299   <- working set the pool must satisfy
+Distinct arrays:         303   <- fresh allocations
+Pool reuse rate:       49.3%
+```
+
+Distinct arrays (303) ≈ peak checked out (299). The pool allocated **one array per slot of the
+working set and reused it thereafter** — ideal behaviour. There was no trim loop, no bucket
+overflow, no TLS problem. `Rent` "missing on every segment" in the EventPipe trace was the pool
+correctly filling a working set that was ~300 buffers wide.
+
+A finalizer counting segments collected while still holding a buffer reported **0**: nothing
+leaked either. The 291 unreturned buffers were simply **still checked out** — alive, referenced,
+sitting in stream channels and slots.
+
+### The actual cause
+
+The backpressure chain has a hole:
+
+```
+producer -> segmentQueue(60) -> workers(30) -> segmentSlots(UNBOUNDED, sized to the whole file)
+         -> orderingTask -> _bufferChannel(60) -> reader
+```
+
+`_bufferChannel` bounds only the **ordering task**, which is *downstream* of the slots. Nothing
+tied the fetch rate to the read rate, so the workers raced to the end of the file, each completed
+segment parking a ~1MB pooled buffer in a slot. **Resident memory scaled with file size, not with
+`bufferSegmentCount`.** The comment at the channel construction ("250 segments = ~500MB") was
+describing a bound that did not exist.
+
+Proof, as a unit test (`BufferedSegmentStreamPrefetchWindowTests`): with the reader stopped after
+**one** segment, the fetchers pulled **500 of 500** segments anyway.
+
+### The fix
+
+The producer holds a segment back until the reader is within `bufferSegmentCount + connections` of
+needing it. `_nextIndexToRead` is always inside the window, so the segment the reader is waiting on
+can never be gated.
+
+| measurement (mock harness, 30 connections) | before | after |
+| --- | --- | --- |
+| peak buffers resident, 200 MB file (293 segments) | 299 — *the whole file* | 179 |
+| peak buffers resident, 400 MB | **OutOfMemoryException** | 183 |
+| peak buffers resident, 1000 MB | — | 185 |
+| LOH after last GC, 200 MB | 376 MB | 238 MB |
+| allocation per MB read, 200 MB | 2.8 MB | 1.9 MB |
+| segments fetched to deliver 293 | 427 | 294 |
+
+Peak resident is **flat across 200/400/1000 MB** — memory is now a function of configuration, not
+of file length. That flatness is the result; the LOH reduction is a side effect of it.
+
+### What is still open
+
+- **Throughput.** Harness sequential speed reads ~13 MB/s after vs ~23 MB/s before. The comparison
+  is confounded and the harness is a poor instrument for it: ~99% of fetch time there is connection
+  acquire (**#18**), the mock provider's breaker trips ~28 times per run on **baseline** too, and
+  the run-to-run spread is 7.6–34.1 MB/s. The baseline bought its number by fetching 1.43× the
+  segments and holding the whole file in RAM — the bug itself. **#18 is the real throughput
+  limiter** and is untouched.
+- **Window vs memory tradeoff.** The window costs `window × 1 MB` per live stream (~90 MB at 30
+  connections), and each buffer is 1 MB serving ~700 KB because 720,896 rounds up to
+  `ArrayPool`'s 1 MB bucket. Right-sizing that is worth ~30% and is not done.
+- **Not verified on the NAS.** The harness models neither the websocket relay nor the 7× provider
+  fan-out. The mechanism (memory ∝ file size) is provider-count-independent, but the numbers above
+  are harness numbers.
+
+### The lesson, again
+
+Four theories, four wrong, all from reading code. The measurements were right every time. The one
+that cracked it took ~20 lines of counters. **Instrument the thing before theorising about it** —
+and note that "the call site is identified" is not the same as "the cause is identified": the
+allocation trace named the exact line, and the line was innocent.


### PR DESCRIPTION
Docs only — no code. Hands off the streaming-OOM investigation so a fresh session can continue without re-deriving it or repeating my mistakes.

Companion to **#19** (the root cause, with measurements), **#14** (reopened and corrected), and **#18** (seek latency).

## What it records

**The cause, measured.** LOH churn at ~109 MB/s — 71% of the process's ~153 MB/s total — refilling the 4 GiB `DOTNET_GCHeapHardLimit` from a stable ~1.15 GB floor every ~25 seconds. At the ceiling there's no headroom, and an allocation failing inside a finalizer is the `Internal CLR error (0x80131506)` we see. Not a leak; not the stats event v0.11.4 optimised.

**Three wrong diagnoses and their common root**, so the next session doesn't make a fourth. All three came from inferring from `GC.GetTotalMemory(false)` and allocation counters. That number includes uncollected garbage, so under Server GC with a hard limit a high allocation rate is *indistinguishable* from a leak. The per-generation `last_collection_heap_size` series answers it in one call and is not in the default `dotnet_*` set — it immediately showed 3.46 GiB on the LOH with Gen2 at 29 MB.

**The trap that made v0.11.4's benchmark look like a production win.** The frontend node server holds a permanent authenticated websocket to the backend as a relay, so `HasSubscribers` is never false in production — while the harness has no websocket and took the bail-out branch instead. Any future "skip work when nobody is listening" optimisation has the same trap.

**Environment facts that invalidate earlier reasoning**: 7 providers (so `UpdateUsageContext`'s fan-out is 7×, not the harness's 1×), and clients are Stremio across web/iOS/Android — not Plex, so many range requests rather than one sequential reader.

Plus NAS access notes, the harness invocation, and the harness's two structural gaps (no websocket, single provider).

Filed under `docs/superpowers/plans/`, which is the path `.gitignore` un-ignores; `docs/plans/` is untracked scratch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
